### PR TITLE
Feat: Add page to directly modify foods in the food database

### DIFF
--- a/src/api/food/get.ts
+++ b/src/api/food/get.ts
@@ -1,5 +1,6 @@
-const getFood = async (uid: string, query: string) => {
-  const res = await fetch(`api/food?user=${uid}&q=${query}`, {
+const getFood = async (uid: string, query?: string) => {
+  const url = `api/food?user=${uid}${query ? `&q=${query}` : ''}`;
+  const res = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/src/api/food/patch.ts
+++ b/src/api/food/patch.ts
@@ -1,0 +1,29 @@
+import { DefinedFoodObject, FoodObject } from '@/interfaces/FoodObject';
+
+interface PatchFood extends DefinedFoodObject {
+  uid: string;
+}
+
+const patchFood = async ({ uid, fid, name, calories, protein, fibre, plantPoints }: PatchFood) => {
+  const res = await fetch(`api/food`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      uid,
+      food: {
+        fid,
+        name,
+        calories,
+        protein,
+        fibre,
+        plantPoints,
+      },
+    }),
+  });
+  const response = await res.json();
+  return response;
+};
+
+export default patchFood;

--- a/src/app/api/food/route.ts
+++ b/src/app/api/food/route.ts
@@ -33,10 +33,22 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const user = searchParams.get('user');
   const query = searchParams.get('q');
+
   const data = await sql`
     SELECT foodobject
     FROM fooddatabase
     WHERE uid like ${user}`;
+  if (!query) {
+    const listOfFoods: DefinedFoodObject[] = [];
+    data.rows.forEach((row) => listOfFoods.push(row.foodobject));
+    listOfFoods.sort((a, b) => {
+      const itemA = a.name.toLowerCase();
+      const itemB = b.name.toLowerCase();
+      return itemA < itemB ? -1 : 1;
+    });
+    return Response.json(listOfFoods);
+  }
+
   const listOfFoods: DefinedFoodObject[] = [];
   data.rows.forEach((row) => {
     const rowName = row.foodobject.name.toLowerCase();
@@ -45,6 +57,7 @@ export async function GET(request: Request) {
       listOfFoods.push(row.foodobject);
     }
   });
+
   return Response.json(listOfFoods);
 }
 
@@ -57,7 +70,20 @@ type Patch = {
   update: Partial<FoodObject>;
 };
 export async function PATCH(request: Request, context: { params: Patch }) {
-  // const team = context.params.team // '1'
+  const body = await request.json();
+  const uid = body.uid;
+  const fid = body.food.fid;
+  const foodobject = JSON.stringify({ ...body.food });
+  const response = await sql<FoodDatabase>`
+   UPDATE fooddatabase
+   SET foodobject = ${foodobject}
+   WHERE uid = ${uid}
+   AND fid = ${fid}`;
+
+  if (response.rowCount == 1) {
+    return Response.json(foodobject);
+  }
+
   return new Response('200');
 }
 

--- a/src/app/foodlist/layout.tsx
+++ b/src/app/foodlist/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata, Viewport } from 'next';
+import { Inter } from 'next/font/google';
+import StyledComponentsRegistry from '@/registry';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'Tracker - TrackCPF',
+  description: 'Track your Calories, Protein, Fibre',
+};
+export const viewport: Viewport = {
+  themeColor: '#000000',
+  initialScale: 1,
+  width: 'device-width',
+  maximumScale: 1,
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <StyledComponentsRegistry>{children}</StyledComponentsRegistry>
+      </body>
+    </html>
+  );
+}

--- a/src/app/foodlist/page.style.tsx
+++ b/src/app/foodlist/page.style.tsx
@@ -1,0 +1,23 @@
+import { theme } from '@/theme';
+import styled from 'styled-components';
+
+export const PageWrapper = styled.div`
+  padding: 16px;
+`;
+
+export const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: ${theme.padding.small};
+  border-bottom: 1px solid ${theme.colours.lightGrey};
+`;
+
+export const FoodEntry = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: ${theme.padding.medium};
+`;
+
+export const ActionBlock = styled.div`
+  display: flex;
+`;

--- a/src/app/foodlist/page.style.tsx
+++ b/src/app/foodlist/page.style.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 
 export const PageWrapper = styled.div`
   padding: 16px;
+  overflow-y: scroll;
+  height: 94vh;
 `;
 
 export const Header = styled.div`

--- a/src/app/foodlist/page.tsx
+++ b/src/app/foodlist/page.tsx
@@ -1,0 +1,153 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import { Settings, MenuBar } from '@/components';
+import { useRouter } from 'next/navigation';
+import { SettingsContext, SettingsContextInterface, defaultSettings } from '@/context';
+import { getSettings } from '@/api/users/settings';
+import { PageWrapper, Header, FoodEntry, ActionBlock } from './page.style';
+import { deleteFood, getFood } from '@/api/food';
+import { DefinedFoodObject, FoodObject } from '@/interfaces/FoodObject';
+import { Delete, PlantPoint } from '@/Icons';
+import { theme } from '@/theme';
+import ModifyFood from '@/components/ModifyItems/ModifyFood';
+import patchFood from '@/api/food/patch';
+
+export default function Home() {
+  const router = useRouter();
+
+  const [uid, setUid] = useState<string>('');
+  const [email, setEmail] = useState<string>('');
+  const [userSettings, setUserSettings] = useState<SettingsContextInterface>(defaultSettings);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [data, setAllData] = useState<DefinedFoodObject[]>([]);
+  const [selectedFood, setSelectedFood] = useState<DefinedFoodObject>();
+
+  const addNewItemRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (addNewItemRef.current && selectedFood) {
+      addNewItemRef.current.scrollIntoView();
+    }
+  }, [selectedFood]);
+
+  // Initial Load to retreive UID & Email
+  useEffect(() => {
+    if (uid !== 'ERROR') {
+      setUid(localStorage.getItem('uid') || 'ERROR');
+      setEmail(localStorage.getItem('email') || 'ERROR');
+    } else {
+      logout();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (uid == 'ERROR') {
+      logout();
+    } else {
+      if (uid != '') {
+        fetchSettings();
+      }
+    }
+  }, [uid]);
+
+  const logout = () => {
+    localStorage.removeItem('uid');
+    localStorage.removeItem('email');
+    router.push('/');
+  };
+
+  async function fetchSettings() {
+    const settings = await getSettings(uid);
+    setUserSettings(settings);
+    await fetchAllFoodItems();
+  }
+
+  async function fetchAllFoodItems() {
+    setSelectedFood(undefined);
+    const response = await getFood(uid);
+    setAllData(response);
+  }
+
+  const closeSettings = async () => {
+    await fetchSettings();
+    setSettingsOpen(false);
+  };
+
+  const handleSaveFoodToDatabase = async ({
+    fid,
+    name,
+    calories,
+    protein,
+    fibre,
+    plantPoints,
+  }: DefinedFoodObject) => {
+    if (selectedFood) {
+      await patchFood({
+        uid,
+        fid,
+        name,
+        calories,
+        protein,
+        fibre,
+        plantPoints,
+      });
+      fetchAllFoodItems();
+    }
+  };
+
+  const handleModifyFoodEntry = (foodItem: DefinedFoodObject) => {
+    setSelectedFood(foodItem);
+  };
+
+  const handleDeleteFoodEntry = async (foodId: string) => {
+    await deleteFood(foodId);
+    await fetchAllFoodItems();
+  };
+
+  return (
+    <SettingsContext.Provider value={userSettings}>
+      <PageWrapper>
+        <Header>
+          <span onClick={() => setSettingsOpen(true)}>User: {email}</span>
+          <button onClick={() => logout()}>Log Out</button>
+        </Header>
+
+        {data &&
+          data.map((foodItem) => {
+            console.log(foodItem);
+            return (
+              <FoodEntry role="button" key={foodItem.fid}>
+                <span onClick={() => handleModifyFoodEntry(foodItem)}>
+                  {foodItem.name || '[MISSING NAME]'} ({foodItem.calories || '[MISSING CALORIES]'}{' '}
+                  cal/100g)
+                  {foodItem.plantPoints ? (
+                    <PlantPoint style={{ fill: theme.colours.plantPoint }} />
+                  ) : (
+                    ''
+                  )}
+                </span>
+                <ActionBlock>
+                  <Delete
+                    size={24}
+                    label="Delete Item from Database"
+                    onClick={(e: React.SyntheticEvent) => {
+                      e.stopPropagation();
+                      handleDeleteFoodEntry(foodItem.fid);
+                    }}
+                  />
+                </ActionBlock>
+              </FoodEntry>
+            );
+          })}
+      </PageWrapper>
+      <MenuBar />
+      <ModifyFood
+        ref={addNewItemRef}
+        isVisible={!!selectedFood}
+        selectedFood={selectedFood}
+        handleSave={handleSaveFoodToDatabase}
+        close={() => setSelectedFood(undefined)}
+      />
+      <Settings title="User Settings" isVisible={settingsOpen} close={closeSettings} uid={uid} />
+    </SettingsContext.Provider>
+  );
+}

--- a/src/app/tracker/Page.style.ts
+++ b/src/app/tracker/Page.style.ts
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 
 export const PageWrapper = styled.div`
   padding: 16px;
+  overflow-y: scroll;
+  height: 94vh;
 `;
 
 export const Header = styled.div`

--- a/src/app/tracker/page.tsx
+++ b/src/app/tracker/page.tsx
@@ -249,7 +249,6 @@ export default function Home() {
         />
         <AddNewItem
           ref={addNewItemRef}
-          date={displayDate}
           isVisible={!!foodMode}
           mode={foodMode}
           name={searchValue}

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -2,12 +2,12 @@ import moment, { Moment } from 'moment';
 import { ChevronLeft, ChevronRight } from '@/Icons';
 import { DatePickerWrapper, DateSelector, Day, YearWrapper } from './DatePicker.style';
 
-interface DatePicker {
+interface DatePickerInterface {
   date: Moment;
   setDisplayDate: (date: Moment) => void;
 }
 
-const DatePicker = ({ date, setDisplayDate }: DatePicker) => {
+const DatePicker = ({ date, setDisplayDate }: DatePickerInterface) => {
   const handleDateChange = (dir: string) => {
     if (dir == 'back') {
       const yesterday = date.clone().subtract(1, 'day');

--- a/src/components/MenuBar/MenuBar.style.ts
+++ b/src/components/MenuBar/MenuBar.style.ts
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 
 export const MenuBarContainer = styled.div`
   position: sticky;
-  height: 60px;
+  //   height: 60px;
+  height: 6vh;
   border-top: 1px solid ${theme.colours.lightGrey};
   display: flex;
   justify-content: space-around;

--- a/src/components/MenuBar/MenuBar.test.tsx
+++ b/src/components/MenuBar/MenuBar.test.tsx
@@ -20,4 +20,11 @@ describe('Menu Bar', () => {
     await userEvent.click(homeBtn);
     expect(mockPush).toHaveBeenCalledWith('/tracker/');
   });
+
+  it('should go to the Food List when Food DB is clicked', async () => {
+    render(<MenuBar />);
+    const foodDbBtn = screen.getByRole('button', { name: 'View Food Database' });
+    await userEvent.click(foodDbBtn);
+    expect(mockPush).toHaveBeenCalledWith('/foodlist/');
+  });
 });

--- a/src/components/MenuBar/MenuBar.tsx
+++ b/src/components/MenuBar/MenuBar.tsx
@@ -15,9 +15,9 @@ const MenuBar = () => {
   };
 
   const handleFoodDatabase = () => {
-    // router.push('/tracker/');
-    // console.log('Database');
+    router.push('/foodlist/');
   };
+
   const menuIconStyle = { color: '#000', cursor: 'pointer' };
   return (
     <MenuBarContainer>
@@ -27,7 +27,7 @@ const MenuBar = () => {
       <MenuItem>
         <AddRecipe size={36} style={menuIconStyle} />
       </MenuItem>
-      <MenuItem>
+      <MenuItem onClick={handleFoodDatabase}>
         <Database size={36} style={menuIconStyle} />
       </MenuItem>
     </MenuBarContainer>

--- a/src/components/ModifyItems/AddNewItem.style.ts
+++ b/src/components/ModifyItems/AddNewItem.style.ts
@@ -19,6 +19,7 @@ export const ItemAttributes = styled.div`
   padding: ${theme.padding.medium};
 `;
 export const EntryLabel = styled.label`
+  justify-content: center;
   font-size: 24px;
   display: flex;
   align-items: center;

--- a/src/components/ModifyItems/AddNewItem.test.tsx
+++ b/src/components/ModifyItems/AddNewItem.test.tsx
@@ -3,8 +3,6 @@ import '@testing-library/jest-dom';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import { AddNewItem } from '@/components';
 import { AddNewItemInterface } from './AddNewItem';
-
-import moment from 'moment';
 import { MODES } from '@/interfaces/ItemModes';
 
 describe('Add New Item modal', () => {

--- a/src/components/ModifyItems/AddNewItem.test.tsx
+++ b/src/components/ModifyItems/AddNewItem.test.tsx
@@ -13,7 +13,6 @@ describe('Add New Item modal', () => {
   const mockDeleteDiaryEntry = jest.fn();
   const defaultProps: AddNewItemInterface = {
     name: 'Food',
-    date: moment('2024-09-11'),
     isVisible: true,
     mode: MODES.CALCULATE,
     handleSave: mockHandleSave,

--- a/src/components/ModifyItems/AddNewItem.tsx
+++ b/src/components/ModifyItems/AddNewItem.tsx
@@ -13,7 +13,6 @@ import {
   DeleteAction,
 } from './AddNewItem.style';
 import { ForwardedRef, forwardRef, useContext, useEffect, useState } from 'react';
-import { Moment } from 'moment';
 import { FoodObject } from '@/interfaces/FoodObject';
 import Modal from '../_Modal/Modal';
 import { SettingsContext } from '@/context';
@@ -23,7 +22,6 @@ export interface AddNewItemInterface {
   name: string;
   selectedFood?: FoodObject;
   selectedFoodServing?: number;
-  date: Moment;
   isVisible: boolean;
   mode: ItemMode;
   diaryEntryId?: string;

--- a/src/components/ModifyItems/ModifyFood.test.tsx
+++ b/src/components/ModifyItems/ModifyFood.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { ModifyFood } from '@/components';
+import { ModifyFoodInterface } from './ModifyFood';
+import { DefinedFoodObject } from '@/interfaces/FoodObject';
+
+describe('Add New Item modal', () => {
+  const mockHandleSave = jest.fn((food: DefinedFoodObject) => null);
+
+  const defaultFoodObject = {
+    fid: 'TEST-FID',
+    name: 'Test Food',
+    calories: 100,
+    protein: 2,
+    fibre: 1.4,
+    plantPoints: 0,
+  };
+  const incompleteFoodObject = {
+    fid: 'TEST-FID',
+    name: 'Test Food',
+    calories: 100,
+    protein: NaN,
+    fibre: 1.4,
+    plantPoints: 0,
+  };
+  const defaultProps: ModifyFoodInterface = {
+    isVisible: true,
+    handleSave: mockHandleSave,
+    close: jest.fn(),
+  };
+
+  const renderAddNewItem = async (food: DefinedFoodObject = defaultFoodObject) => {
+    render(<ModifyFood {...defaultProps} selectedFood={food} />);
+    const user = userEvent.setup();
+
+    return { user };
+  };
+
+  const enterData = async ({
+    cal,
+    pro,
+    fib,
+    plant,
+  }: {
+    cal?: number;
+    pro?: number;
+    fib?: number;
+    plant?: number;
+  }) => {
+    const caloriesInput = await screen.findByRole('textbox', { name: 'Calories' });
+    const proteinInput = await screen.findByRole('textbox', { name: 'Protein' });
+    const fiberInput = await screen.findByRole('textbox', { name: 'Fibre' });
+    const plantPointsInput = await screen.findByRole('combobox', { name: 'Plant Points' });
+    const saveButton = await screen.findByRole('button', { name: 'Update Entry' });
+
+    if (typeof cal == 'number') {
+      await userEvent.clear(caloriesInput);
+      await userEvent.type(caloriesInput, cal.toString());
+    }
+
+    if (typeof pro == 'number') {
+      await userEvent.clear(proteinInput);
+      await userEvent.type(proteinInput, pro.toString());
+    }
+    if (typeof fib == 'number') {
+      await userEvent.clear(fiberInput);
+      await userEvent.type(fiberInput, fib.toString());
+    }
+
+    if (typeof plant == 'number') {
+      await userEvent.selectOptions(plantPointsInput, plant.toString());
+    }
+
+    await userEvent.click(saveButton);
+  };
+
+  beforeEach(function () {
+    mockHandleSave.mockClear();
+  });
+
+  it('Should update database with new info', async () => {
+    await renderAddNewItem();
+    await enterData({ cal: 120, pro: 2.5, fib: 1.4 });
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+    expect(mockHandleSave).toHaveBeenCalledWith({
+      fid: defaultFoodObject.fid,
+      name: defaultFoodObject.name,
+      calories: 120,
+      protein: 2.5,
+      fibre: 1.4,
+      plantPoints: 0,
+    });
+  });
+
+  it('Should update database with new info including 0-values', async () => {
+    await renderAddNewItem();
+    await enterData({ cal: 120, pro: 0, fib: 1.4 });
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+    expect(mockHandleSave).toHaveBeenCalledWith({
+      fid: defaultFoodObject.fid,
+      name: defaultFoodObject.name,
+      calories: 120,
+      protein: 0,
+      fibre: 1.4,
+      plantPoints: 0,
+    });
+  });
+
+  it('Should update database from incomplete starting data', async () => {
+    await renderAddNewItem(incompleteFoodObject);
+    await enterData({ cal: 120, pro: 2.5, fib: 1.4 });
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+    expect(mockHandleSave).toHaveBeenCalledWith({
+      fid: defaultFoodObject.fid,
+      name: defaultFoodObject.name,
+      calories: 120,
+      protein: 2.5,
+      fibre: 1.4,
+      plantPoints: 0,
+    });
+  });
+
+  it('Should update database entry with info removed', async () => {
+    await renderAddNewItem();
+
+    const proteinInput = await screen.findByRole('textbox', { name: 'Protein' });
+    await userEvent.clear(proteinInput);
+
+    const saveButton = await screen.findByRole('button', { name: 'Update Entry' });
+    await userEvent.click(saveButton);
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+    expect(mockHandleSave).toHaveBeenCalledWith({
+      fid: defaultFoodObject.fid,
+      name: defaultFoodObject.name,
+      calories: defaultFoodObject.calories,
+      protein: NaN,
+      fibre: defaultFoodObject.fibre,
+      plantPoints: defaultFoodObject.plantPoints,
+    });
+  });
+
+  it('Should save to diary with 1 plant points', async () => {
+    await renderAddNewItem();
+    await enterData({ plant: 1 });
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+    expect(mockHandleSave).toHaveBeenCalledWith({
+      fid: defaultFoodObject.fid,
+      name: defaultFoodObject.name,
+      calories: defaultFoodObject.calories,
+      protein: defaultFoodObject.protein,
+      fibre: defaultFoodObject.fibre,
+      plantPoints: 1,
+    });
+  });
+});

--- a/src/components/ModifyItems/ModifyFood.tsx
+++ b/src/components/ModifyItems/ModifyFood.tsx
@@ -1,0 +1,152 @@
+import { NullableNumber } from '@/interfaces/ItemModes';
+import {
+  Actions,
+  DiscardAction,
+  EntryBox,
+  ItemAttributes,
+  NewItemModal,
+  SaveAction,
+  AttributeInput,
+  TextDisplay,
+  EntryLabel,
+  PlantPointsSelector,
+  DeleteAction,
+} from './AddNewItem.style';
+import { ForwardedRef, forwardRef, useContext, useEffect, useState } from 'react';
+import { DefinedFoodObject, FoodObject } from '@/interfaces/FoodObject';
+import Modal from '../_Modal/Modal';
+import { SettingsContext } from '@/context';
+import { Delete } from '@/Icons';
+
+export interface ModifyFood {
+  selectedFood?: DefinedFoodObject;
+  isVisible: boolean;
+  handleSave: (food: DefinedFoodObject) => void;
+  close: () => void;
+}
+
+const ModifyFood = forwardRef(
+  (
+    { selectedFood, handleSave, isVisible, close }: ModifyFood,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) => {
+    const context = useContext(SettingsContext);
+    const { usePlantPoints } = context;
+
+    if (!selectedFood) {
+      return <></>;
+    }
+
+    const [entryName, setEntryName] = useState<string>();
+    const [calories, setCalories] = useState<string>();
+    const [protein, setProtein] = useState<string>();
+    const [fibre, setFibre] = useState<string>();
+    const [plantPoints, setPlantPoints] = useState<string>('0');
+
+    useEffect(() => {
+      if (selectedFood) {
+        setEntryName(selectedFood.name.toString());
+        setCalories(selectedFood.calories?.toString());
+        setProtein(selectedFood.protein?.toString());
+        setFibre(selectedFood.fibre?.toString());
+        setPlantPoints(selectedFood.plantPoints?.toString() || '0');
+      }
+    }, [selectedFood]);
+
+    const resetForm = () => {
+      setEntryName(undefined);
+      setCalories(undefined);
+      setProtein(undefined);
+      setFibre(undefined);
+      setPlantPoints('0');
+    };
+    const handleDiscard = () => {
+      resetForm();
+      close();
+    };
+
+    const handleSubmit = () => {
+      handleSave({
+        fid: selectedFood.fid,
+        name: selectedFood.name,
+        calories: parseFloat(calories || ''),
+        protein: parseFloat(protein || ''),
+        fibre: parseFloat(fibre || ''),
+        plantPoints: parseFloat(plantPoints || '0'),
+      });
+
+      resetForm();
+    };
+
+    return (
+      <Modal title="Modify Database Entry" isVisible={isVisible} close={close} ref={ref}>
+        <NewItemModal id="foodObjectForm" action={handleSubmit}>
+          <span>
+            Modifying or deleting items from this page will affect what is offered to you in the
+            dropdown when you are creating your food diary. It will NOT modify any existing diary
+            entries, only change what is avaialble to you for future entries.
+          </span>
+          <ItemAttributes>
+            <EntryLabel>{entryName} per 100g</EntryLabel>
+            <EntryBox>
+              <AttributeInput
+                id="calories"
+                inputMode="decimal"
+                value={calories || ''}
+                onChange={(e) => setCalories(e.target.value)}
+              />
+              <TextDisplay htmlFor="calories">Calories</TextDisplay>
+            </EntryBox>
+            <EntryBox>
+              <AttributeInput
+                id="protein"
+                inputMode="decimal"
+                value={protein || ''}
+                onChange={(e) => setProtein(e.target.value)}
+              />
+              <TextDisplay htmlFor="protein">Protein</TextDisplay>
+            </EntryBox>
+            <EntryBox>
+              <AttributeInput
+                id="fibre"
+                inputMode="decimal"
+                value={fibre || ''}
+                onChange={(e) => setFibre(e.target.value)}
+              />
+              <TextDisplay htmlFor="fibre">Fibre</TextDisplay>
+            </EntryBox>
+            {usePlantPoints && (
+              <EntryBox>
+                <PlantPointsSelector
+                  aria-label="Plant Points"
+                  id="plantPoints"
+                  value={plantPoints}
+                  onChange={(e) => setPlantPoints(e.target.value)}
+                >
+                  <option value={0}>0 Plant Points</option>
+                  <option value={1}>1 Plant Point</option>
+                  <option value={0.5}>1/2 Plant Point</option>
+                  <option value={0.25}>1/4 Plant Point</option>
+                </PlantPointsSelector>
+              </EntryBox>
+            )}
+          </ItemAttributes>
+
+          <Actions>
+            <DiscardAction onClick={handleDiscard}>Discard Changes</DiscardAction>
+            <SaveAction type={'submit'}>Update Entry</SaveAction>
+          </Actions>
+
+          {/* <Actions>
+            <DeleteAction onClick={() => deleteFood(foodId)}>
+              <Delete size={24} label={`Delete ${name}`} />
+              {'Delete Food from Database'}
+            </DeleteAction>
+          </Actions> */}
+        </NewItemModal>
+      </Modal>
+    );
+  },
+);
+
+export default ModifyFood;

--- a/src/components/ModifyItems/ModifyFood.tsx
+++ b/src/components/ModifyItems/ModifyFood.tsx
@@ -1,4 +1,3 @@
-import { NullableNumber } from '@/interfaces/ItemModes';
 import {
   Actions,
   DiscardAction,
@@ -10,15 +9,13 @@ import {
   TextDisplay,
   EntryLabel,
   PlantPointsSelector,
-  DeleteAction,
 } from './AddNewItem.style';
 import { ForwardedRef, forwardRef, useContext, useEffect, useState } from 'react';
-import { DefinedFoodObject, FoodObject } from '@/interfaces/FoodObject';
+import { DefinedFoodObject } from '@/interfaces/FoodObject';
 import Modal from '../_Modal/Modal';
 import { SettingsContext } from '@/context';
-import { Delete } from '@/Icons';
 
-export interface ModifyFood {
+export interface ModifyFoodInterface {
   selectedFood?: DefinedFoodObject;
   isVisible: boolean;
   handleSave: (food: DefinedFoodObject) => void;
@@ -27,7 +24,7 @@ export interface ModifyFood {
 
 const ModifyFood = forwardRef(
   (
-    { selectedFood, handleSave, isVisible, close }: ModifyFood,
+    { selectedFood, handleSave, isVisible, close }: ModifyFoodInterface,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
     const context = useContext(SettingsContext);
@@ -37,7 +34,6 @@ const ModifyFood = forwardRef(
       return <></>;
     }
 
-    const [entryName, setEntryName] = useState<string>();
     const [calories, setCalories] = useState<string>();
     const [protein, setProtein] = useState<string>();
     const [fibre, setFibre] = useState<string>();
@@ -45,7 +41,6 @@ const ModifyFood = forwardRef(
 
     useEffect(() => {
       if (selectedFood) {
-        setEntryName(selectedFood.name.toString());
         setCalories(selectedFood.calories?.toString());
         setProtein(selectedFood.protein?.toString());
         setFibre(selectedFood.fibre?.toString());
@@ -54,12 +49,12 @@ const ModifyFood = forwardRef(
     }, [selectedFood]);
 
     const resetForm = () => {
-      setEntryName(undefined);
       setCalories(undefined);
       setProtein(undefined);
       setFibre(undefined);
       setPlantPoints('0');
     };
+
     const handleDiscard = () => {
       resetForm();
       close();
@@ -87,7 +82,7 @@ const ModifyFood = forwardRef(
             entries, only change what is avaialble to you for future entries.
           </span>
           <ItemAttributes>
-            <EntryLabel>{entryName} per 100g</EntryLabel>
+            <EntryLabel>{selectedFood.name} per 100g</EntryLabel>
             <EntryBox>
               <AttributeInput
                 id="calories"
@@ -136,13 +131,6 @@ const ModifyFood = forwardRef(
             <DiscardAction onClick={handleDiscard}>Discard Changes</DiscardAction>
             <SaveAction type={'submit'}>Update Entry</SaveAction>
           </Actions>
-
-          {/* <Actions>
-            <DeleteAction onClick={() => deleteFood(foodId)}>
-              <Delete size={24} label={`Delete ${name}`} />
-              {'Delete Food from Database'}
-            </DeleteAction>
-          </Actions> */}
         </NewItemModal>
       </Modal>
     );

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -4,7 +4,7 @@ import { ActionBlock, ResponseDropdown, ResponseRow, SearchBarInput } from './Se
 import { DefinedFoodObject } from '@/interfaces/FoodObject';
 import { ForwardedRef, forwardRef, useState } from 'react';
 
-interface SearchBar {
+interface SearchBarInterface {
   value: string;
   setValue: (val: string) => void;
   response: DefinedFoodObject[];
@@ -15,7 +15,7 @@ interface SearchBar {
 
 const SearchBar = forwardRef(
   (
-    { value, setValue, response, addNewItem, setSelectedFood, deleteFoodItem }: SearchBar,
+    { value, setValue, response, addNewItem, setSelectedFood, deleteFoodItem }: SearchBarInterface,
     ref: ForwardedRef<HTMLInputElement>,
   ) => {
     const [showDropdown, setShowDropdown] = useState(false);

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -19,10 +19,10 @@ import {
   SettingsContext,
 } from '@/context';
 
-interface Settings extends Omit<ModalInterface, 'children'> {
+interface SettingsInterface extends Omit<ModalInterface, 'children'> {
   uid: string;
 }
-const Settings = ({ title, close, isVisible, uid }: Settings) => {
+const Settings = ({ title, close, isVisible, uid }: SettingsInterface) => {
   const context = useContext(SettingsContext);
   const [gender, setGender] = useState<Genders>(context.gender);
   const [age, setAge] = useState<number>(context.age);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,8 +2,9 @@ import AddNewItem from './ModifyItems/AddNewItem';
 import DatePicker from './DatePicker/DatePicker';
 import MainDisplay from './MainDisplay/MainDisplay';
 import MenuBar from './MenuBar/MenuBar';
+import ModifyFood from './ModifyItems/ModifyFood';
 import SearchBar from './SearchBar/SearchBar';
 import Summary from './Summary/Summary';
 import Settings from './Settings/Settings';
 
-export { AddNewItem, DatePicker, MainDisplay, MenuBar, SearchBar, Settings, Summary };
+export { AddNewItem, DatePicker, MainDisplay, MenuBar, ModifyFood, SearchBar, Settings, Summary };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,4 @@
-import AddNewItem from './AddNewItem/AddNewItem';
+import AddNewItem from './ModifyItems/AddNewItem';
 import DatePicker from './DatePicker/DatePicker';
 import MainDisplay from './MainDisplay/MainDisplay';
 import MenuBar from './MenuBar/MenuBar';

--- a/src/interfaces/ItemModes.ts
+++ b/src/interfaces/ItemModes.ts
@@ -20,8 +20,9 @@ export enum MODES {
   MANUAL = 'manual',
   CALCULATE = 'calculate',
   UPDATE = 'update',
+  PATCH = 'patch',
 }
 
-export type ItemMode = MODES.MANUAL | MODES.CALCULATE | MODES.UPDATE | null;
+export type ItemMode = MODES.MANUAL | MODES.CALCULATE | MODES.UPDATE | MODES.PATCH | null;
 
 export type NullableNumber = number | null | typeof NaN | undefined;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -14,10 +14,6 @@ export const theme = {
     plantPoint: '#45f248', // '#B0AB80',
   },
 
-  //   layoutPadding: '24px',
-  //   buttonPadding: '12px',
-  //   inputPadding: '6px',
-
   padding: {
     small: '6px',
     medium: '12px',


### PR DESCRIPTION
Added ability to access the food database and make modifications to saved items -- for updating plant points, easily clearing out unnecessary entries, and updating nutrition information as products change.

This is accessed via the floating menu. This upgrades the feature initially implemented for https://github.com/Cskelton77/trackCPF/issues/17, and adds the feature described in https://github.com/Cskelton77/trackCPF/issues/9

![Screenshot 2024-09-28 at 22 44 48](https://github.com/user-attachments/assets/eda98a68-21d8-4155-8bfd-5cfcffc35441)

![Screenshot 2024-09-28 at 22 44 56](https://github.com/user-attachments/assets/c628a253-c3c5-4acf-8f1d-3052b920854f)
